### PR TITLE
Resolve `AttributeError: 'NoneType' object has no attribute 'shape'` by updating auffusion_pipeline.py

### DIFF
--- a/auffusion_pipeline.py
+++ b/auffusion_pipeline.py
@@ -742,6 +742,7 @@ class AuffusionPipeline(DiffusionPipeline):
                 )
             elif isinstance(negative_prompt, str):
                 negative_prompt = [negative_prompt]
+                negative_prompt_embeds = get_prompt_embeds(negative_prompt, device)
             elif batch_size != len(negative_prompt):
                 raise ValueError(
                     f"`negative_prompt`: {negative_prompt} has batch size {len(negative_prompt)}, but `prompt`:"


### PR DESCRIPTION
First, thanks for the great work of Auffusion! It's amazing fast and easy to run!

For now when giving `negative_prompt` to `pipeline`, an error would be raised:
```
Traceback (most recent call last):
  File "D:\path\Auffusion\test.py", line 8, in <module>
    output = pipeline(prompt=prompt, negative_prompt="Low quality, average quality.")
  File "D:\path\Auffusion\venv\lib\site-packages\torch\utils\_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "D:\path\Auffusion\auffusion_pipeline.py", line 934, in __call__
    prompt_embeds = self._encode_prompt(
  File "D:\path\Auffusion\auffusion_pipeline.py", line 757, in _encode_prompt
    seq_len = negative_prompt_embeds.shape[1]
AttributeError: 'NoneType' object has no attribute 'shape'
```
It seems like the `negative_prompt_embeds` hasn't been inited when `elif isinstance(negative_prompt, str)` in `auffusion_pipeline.py`:
```
  ...
  if negative_prompt is None:
      negative_prompt_embeds = torch.zeros_like(prompt_embeds).to(dtype=prompt_embeds.dtype, device=device)
  elif isinstance(negative_prompt, str):
      negative_prompt = [negative_prompt]
      # negative_prompt_embeds remains None here.
  ...
  else:
      negative_prompt_embeds = get_prompt_embeds(negative_prompt, device)
```

This PR is about adding a line to init `negative_prompt_embes` like:
`negative_prompt_embeds = get_prompt_embeds(negative_prompt, device)`